### PR TITLE
fix fully transparent nautilus sidebar

### DIFF
--- a/gtk-3.20/apps/vibrancy.css
+++ b/gtk-3.20/apps/vibrancy.css
@@ -3,7 +3,7 @@ filechooser.csd.background,
 filechooser placessidebar list,
 .nautilus-window.csd.background,
 .nautilus-window placessidebar list {
-    background-color: transparent;
+    background-color: alpha(@theme_bg_color, 0.8)
 }
         
 .sidebar,


### PR DESCRIPTION
First I wanted to thank you for a magnificent theme. I also found a small back and made a PR with a fix that I hope will make it in.

Specifically the Nautilus places sidebar was full transparent, which made it hard to see depending on the background. Based on the related styles it looks like it should 0.8 translucent (look at styles below it). I am attaching screenshot as a demonstration and hope the fix makes sense.

![nautilus sidebar is too transparent](https://user-images.githubusercontent.com/582074/42558067-ffeb2522-84a4-11e8-9d75-77d96cdeac16.png)
